### PR TITLE
Add CNAME for a custom domain handling

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+kaunasphp.lt


### PR DESCRIPTION
To make this work without a redirect from kaunasphp.lt to kaunasphp.github.io it is required to configure CNAME record in DNS, see: https://help.github.com/articles/tips-for-configuring-a-cname-record-with-your-dns-provider/

Whole manual regarding custom domains is here: https://help.github.com/articles/setting-up-a-custom-domain-with-github-pages/